### PR TITLE
Add CWD to Python path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+env:
+- PYTHONPATH=.
 python:
   - "3.5"
 install: "pip install -r requirements.txt"


### PR DESCRIPTION
Python needs to be told to look in the root of your repo for things to import. This PR accomplishes this by setting an environment variable.